### PR TITLE
chore: Install multiple versions of Python on Windows CI.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,7 +84,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12 - 3.13"
+          python-version: |
+              3.12
+              3.13
           architecture: ${{ matrix.platform.target }}
       - name: Build wheels
         uses: PyO3/maturin-action@v1


### PR DESCRIPTION
https://github.com/Apricot-S/xiangting-py/actions/runs/11728678707/job/32673035319

他のプラットフォームと同様の "3.12 - 3.13" の指定では 3.13 がインストールされず、CI が失敗する。