### PR TITLE
docs: Change the link for xiangting from the GitHub repository to crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # xiangting-py
 
-Python bindings for [xiangting](https://github.com/Apricot-S/xiangting).
+Python bindings for [xiangting](https://crates.io/crates/xiangting).
 
-See also [xiangting](https://github.com/Apricot-S/xiangting) for more information.
+See also [xiangting](https://crates.io/crates/xiangting) for more information.
 
 Documentation:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@ use crate::calculate::{calculate_replacement_number, calculate_replacement_numbe
 use crate::fulu_mianzi::{ClaimedTilePosition, FuluMianzi};
 use pyo3::prelude::*;
 
-/// Python bindings for `xiangting <https://github.com/Apricot-S/xiangting>`_.
+/// Python bindings for `xiangting <https://crates.io/crates/xiangting>`_.
 ///
-/// See also `xiangting <https://github.com/Apricot-S/xiangting>`_ for
+/// See also `xiangting <https://crates.io/crates/xiangting>`_ for
 /// more information.
 ///
 /// The hand is represented by the number of each tile in an array of


### PR DESCRIPTION
xiangting を crates.io に登録したので、ドキュメント内のリンク先を GitHub から crates.io に変える。