### PR TITLE
chore: Make `license` field format compliant with PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "xiangting"
 version = "3.1.2"
 description = "Python bindings for xiangting"
 authors = [{ name = "Apricot S." }]
-license = { text = "MIT License" }
+license = "MIT"
 readme = "README.md"
 requires-python = ">=3.12"
 keywords = ["mahjong", "shanten", "xiangting"]


### PR DESCRIPTION
T/O