### PR TITLE
chore: Add `license-files` field compliant with PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "3.1.2"
 description = "Python bindings for xiangting"
 authors = [{ name = "Apricot S." }]
 license = "MIT"
+license-files = ["LICENSE", "THIRD-PARTY-NOTICES.md"]
 readme = "README.md"
 requires-python = ">=3.12"
 keywords = ["mahjong", "shanten", "xiangting"]


### PR DESCRIPTION
T/O