### PR TITLE
chore: Stop providing macOS x86_64 (Intel) wheels

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,8 +104,6 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13
-            target: x86_64
           - runner: macos-14
             target: aarch64
     steps:


### PR DESCRIPTION
Apple による x86_64 アーキテクチャのサポート終了に合わせて GitHub Actions のランナーも廃止されるため、先に wheel のビルドの対応を終了する