### PR TITLE
chore: Remove PyPy classifier (no PyPy wheels published)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
Remove PyPy classifier from `pyproject.toml`.

Reason:
- We currently do not publish PyPy-specific wheels to PyPI.
- Keeping the classifier suggests PyPy support that is not actually provided.
- This change avoids misleading users and keeps metadata aligned with distributed artifacts.