### PR TITLE
docs: Use "xiàngtīng" instead of "xiangting" in documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The correspondence between the index and the tile is shown in the table below.
 | ----- | --------- | ---------- | --------- | ---------- | ---------- | ---------- | -------- |
 | Tile  | East (1z) | South (2z) | West (3z) | North (4z) | White (5z) | Green (6z) | Red (7z) |
 
-Calculates the replacement number, which is equal to the deficiency number (a.k.a. xiangting number, 向聴数) + 1.
+Calculates the replacement number, which is equal to the deficiency number (a.k.a. xiàngtīng number, 向聴数) + 1.
 
 ```python
 from xiangting import PlayerCount, calculate_replacement_number

--- a/src/necessary_tiles.rs
+++ b/src/necessary_tiles.rs
@@ -7,7 +7,7 @@ use crate::config::PlayerCount;
 use ::xiangting::{TileCounts, TileFlags};
 use pyo3::prelude::*;
 
-/// Calculates the replacement number (= xiangting number + 1) and necessary tiles for a given hand.
+/// Calculates the replacement number (= xiàngtīng number + 1) and necessary tiles for a given hand.
 ///
 /// Args:
 ///     bingpai (list[int]): 兵牌: A hand excluding melds
@@ -16,7 +16,7 @@ use pyo3::prelude::*;
 ///
 /// Returns:
 ///     tuple[int, int]: A tuple (rn, nt), where rn is the replacement
-///     number (= xiangting number + 1), and nt is a bit flag set
+///     number (= xiàngtīng number + 1), and nt is a bit flag set
 ///     representing necessary tiles.
 ///
 /// Raises:

--- a/src/replacement_number.rs
+++ b/src/replacement_number.rs
@@ -7,7 +7,7 @@ use crate::config::PlayerCount;
 use ::xiangting::TileCounts;
 use pyo3::prelude::*;
 
-/// Calculates the replacement number (= xiangting number + 1) for a given hand.
+/// Calculates the replacement number (= xiàngtīng number + 1) for a given hand.
 ///
 /// Args:
 ///     bingpai (list[int]): 兵牌: A hand excluding melds
@@ -15,7 +15,7 @@ use pyo3::prelude::*;
 ///     player_count (PlayerCount): The number of players.
 ///
 /// Returns:
-///     int: The replacement number (= xiangting number + 1).
+///     int: The replacement number (= xiàngtīng number + 1).
 ///
 /// Raises:
 ///     ValueError: If the hand is invalid.

--- a/src/unnecessary_tiles.rs
+++ b/src/unnecessary_tiles.rs
@@ -7,7 +7,7 @@ use crate::config::PlayerCount;
 use ::xiangting::{TileCounts, TileFlags};
 use pyo3::prelude::*;
 
-/// Calculates the replacement number (= xiangting number + 1) and unnecessary tiles for a given hand.
+/// Calculates the replacement number (= xiàngtīng number + 1) and unnecessary tiles for a given hand.
 ///
 /// Args:
 ///     bingpai (list[int]): 兵牌: A hand excluding melds
@@ -16,7 +16,7 @@ use pyo3::prelude::*;
 ///
 /// Returns:
 ///     tuple[int, int]: A tuple (rn, ut), where rn is the replacement
-///     number (= xiangting number + 1), and ut is a bit flag set
+///     number (= xiàngtīng number + 1), and ut is a bit flag set
 ///     representing unnecessary tiles.
 ///
 /// Raises:


### PR DESCRIPTION
T/O