### PR TITLE
chore: Update kago-utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ test = [
     "pytest>=9.0.1,<10",
     "pytest-benchmark>=5.2.3,<6",
     "mahjong>=1.4.0",
-    "kago-utils",
+    "kago-utils>=0.1.4",
 ]
 docs = [
     "sphinx>=8.2.3,<9",
@@ -54,9 +54,6 @@ typing = [
 build = [
     "maturin>=1.10.2,<2",
 ]
-
-[tool.uv.sources]
-kago-utils = { git = "https://github.com/zurukumo/kago-utils", tag = "v0.1.5" }
 
 [tool.maturin]
 features = ["pyo3/extension-module"]


### PR DESCRIPTION
kago-utils の最新版が PyPI からのインストールに対応したので更新する。